### PR TITLE
u-boot: Specify u-boot package for AST2500 machines

### DIFF
--- a/meta-zvezda/meta-iridium/conf/machine/iridium.conf
+++ b/meta-zvezda/meta-iridium/conf/machine/iridium.conf
@@ -1,6 +1,10 @@
 KMACHINE = "aspeed"
 KERNEL_DEVICETREE = "${KMACHINE}-bmc-zvezda-${MACHINE}.dtb"
 
+PREFERRED_PROVIDER_virtual/bootloader = "u-boot-aspeed"
+PREFERRED_PROVIDER_u-boot = "u-boot-aspeed"
+PREFERRED_PROVIDER_u-boot-fw-utils = "u-boot-fw-utils-aspeed"
+
 UBOOT_MACHINE = "ast_g5_ncsi_config"
 
 require conf/machine/include/zvezda.inc


### PR DESCRIPTION
This sets u-boot to the package containing the v2016.07-aspeed-openbmc
branch. This ensures there will be no change if the default changes in
the future.

